### PR TITLE
Make parser capable of parsing the pony standard library

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/build/debug/test.exe",
       "args": [
-        "--only=parser/typedef/Method/complex"
+        "--only=parser/src_file/stdlib/error_section"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ and can recover from errors in functions or classes.
 
 Start with [Builder](https://github.com/chalcolith/eohippus/blob/main/eohippus/parser/builder.pony)
 
-> The parser is mostly complete, but fails to parse some of the Pony standard
-> library files.  See #18
-
 ## [Analyzer](https://github.com/chalcolith/eohippus/tree/main/eohippus/analyzer)
 
 Provides [an actor](https://github.com/chalcolith/eohippus/blob/main/eohippus/analyzer/analyzer.pony)
-that coordinates the analysis (currently parsing, rudimentary scope analysis, and 
+that coordinates the analysis (currently parsing, rudimentary scope analysis, and
 linting) of a workspace containing Pony source files.
 
 ## [Linter](https://github.com/chalcolith/eohippus/tree/main/eohippus/linter)

--- a/eohippus/analyzer/analyzer.pony
+++ b/eohippus/analyzer/analyzer.pony
@@ -250,20 +250,22 @@ actor EohippusAnalyzer is Analyzer
         end
       end
     end
-    match _pony_packages_path
-    | let pp: FilePath =>
-      _log(Fine) and _log.log("pony_packages_path is " + pp.path)
-      //analyze(_analysis_task_id, Path.join(pp.path, "builtin"))
-      _analysis_task_id = _analysis_task_id + 1
-    else
-      _log(Fine) and _log.log("pony_packages_path is None")
-    end
 
     // if we are in a workspace, start analyzing
     match _workspace
     | let workspace_path: FilePath =>
       analyze(_analysis_task_id, workspace_path.path)
       _analysis_task_id = _analysis_task_id + 1
+
+      // make sure we have pony packages
+      match _pony_packages_path
+      | let pp: FilePath =>
+        _log(Fine) and _log.log("pony_packages_path is " + pp.path)
+        analyze(_analysis_task_id, Path.join(pp.path, "builtin"))
+        _analysis_task_id = _analysis_task_id + 1
+      else
+        _log(Fine) and _log.log("pony_packages_path is None")
+      end
     end
 
   fun ref _get_next_task_id(): USize =>

--- a/eohippus/analyzer/analyzer.pony
+++ b/eohippus/analyzer/analyzer.pony
@@ -1090,8 +1090,7 @@ actor EohippusAnalyzer is Analyzer
       let node = ast.NodeWith[ast.SrcFile](
         ast.SrcInfo(canonical_path),
         [ error_section ],
-        ast.SrcFile(canonical_path, [], [])
-        where error_sections' = [ error_section ])
+        ast.SrcFile(canonical_path, [], []))
       _write_syntax_tree(src_file, node)
 
       _log(Fine) and _log.log(

--- a/eohippus/ast/exp_try.pony
+++ b/eohippus/ast/exp_try.pony
@@ -3,11 +3,11 @@ use json = "../json"
 class val ExpTry is NodeData
   """A `try` block."""
 
-  let body: NodeWith[Expression]
+  let body: (NodeWith[Expression] | None)
   let else_block: (NodeWith[Expression] | None)
 
   new val create(
-    body': NodeWith[Expression],
+    body': (NodeWith[Expression] | None),
     else_block': (NodeWith[Expression] | None))
   =>
     body = body'
@@ -17,11 +17,14 @@ class val ExpTry is NodeData
 
   fun val clone(updates: ChildUpdateMap): NodeData =>
     ExpTry(
-      _map_with[Expression](body, updates),
+      _map_or_none[Expression](body, updates),
       _map_or_none[Expression](else_block, updates))
 
   fun add_json_props(node: Node box, props: Array[(String, json.Item)]) =>
-    props.push(("body", node.child_ref(body)))
+    match body
+    | let body': NodeWith[Expression] =>
+      props.push(("body", node.child_ref(body')))
+    end
     match else_block
     | let else_block': NodeWith[Expression] =>
       props.push(("else_block", node.child_ref(else_block')))
@@ -39,8 +42,6 @@ primitive ParseExpTry
         node
       | let err: String =>
         return err
-      else
-        return "ExpTry.body must be an Expression"
       end
     let else_block =
       match ParseNode._get_child_with[Expression](

--- a/eohippus/ast/node.pony
+++ b/eohippus/ast/node.pony
@@ -24,7 +24,6 @@ trait val Node
     doc_strings': (NodeSeqWith[DocString] | None) = None,
     pre_trivia': (NodeSeqWith[Trivia] | None) = None,
     post_trivia': (NodeSeqWith[Trivia] | None) = None,
-    error_sections': (NodeSeqWith[ErrorSection] | None) = None,
     ast_type': (types.AstType | None) = None,
     scope_index': (USize | None) = None): Node
     """
@@ -47,8 +46,6 @@ trait val Node
   fun pre_trivia(): NodeSeqWith[Trivia]
 
   fun post_trivia(): NodeSeqWith[Trivia]
-
-  fun error_sections(): NodeSeqWith[ErrorSection]
 
   fun ast_type(): (types.AstType | None)
     """The resolved type of the node."""

--- a/eohippus/ast/parse_node.pony
+++ b/eohippus/ast/parse_node.pony
@@ -125,18 +125,6 @@ primitive ParseNode
       | let err: String =>
         return err
       end
-    let error_sections =
-      match _get_seq_with[ErrorSection](
-        obj,
-        children,
-        "error_sections",
-        "error_sections must refer to ErrorSections",
-        false)
-      | let seq: NodeSeqWith[ErrorSection] =>
-        seq
-      | let err: String =>
-        return err
-      end
 
     let ctor: (_NodeConstructor | None) =
       match name
@@ -272,7 +260,6 @@ primitive ParseNode
         doc_strings,
         pre_trivia,
         post_trivia,
-        error_sections,
         scope_index)
     else
       "unknown node data type " + name
@@ -368,7 +355,6 @@ primitive ParseNode
     doc_strings: NodeSeqWith[DocString],
     pre_trivia: NodeSeqWith[Trivia],
     post_trivia: NodeSeqWith[Trivia],
-    error_sections: NodeSeqWith[ErrorSection],
     scope_index: (USize | None))
     : (Node | String)
   =>
@@ -388,7 +374,6 @@ primitive ParseNode
       doc_strings,
       pre_trivia,
       post_trivia,
-      error_sections,
       None,
       scope_index)
 
@@ -399,6 +384,5 @@ type _NodeConstructor is
     NodeSeqWith[DocString],
     NodeSeqWith[Trivia],
     NodeSeqWith[Trivia],
-    NodeSeqWith[ErrorSection],
     (USize | None))
     : (Node | String)} box

--- a/eohippus/error_msg.pony
+++ b/eohippus/error_msg.pony
@@ -7,6 +7,9 @@ primitive ErrorMsg
   fun tag internal_ast_pass_clone(): String =>
     "Internal error: invalid node_data when cloning"
 
+  fun tag expression_block_empty(): String =>
+    "Expected an expression sequence"
+
   fun tag literal_integer_hex_empty(): String =>
     "You must supply some hexadecimal digits here"
 

--- a/eohippus/parser/_build.pony
+++ b/eohippus/parser/_build.pony
@@ -93,8 +93,7 @@ primitive _Build
   fun values_and_errors[D: ast.NodeData val](
     b: Bindings,
     v: Variable,
-    r: Success,
-    e: Array[ast.NodeWith[ast.ErrorSection]] ref)
+    r: Success)
     : ast.NodeSeqWith[D]
   =>
     """
@@ -108,8 +107,6 @@ primitive _Build
         match vval
         | let node: ast.NodeWith[D] =>
           rvals.push(node)
-        | let err: ast.NodeWith[ast.ErrorSection] =>
-          e.push(err)
         end
       end
     end

--- a/eohippus/parser/_exp_actions.pony
+++ b/eohippus/parser/_exp_actions.pony
@@ -660,7 +660,7 @@ primitive _ExpActions
         return _Build.bind_error(d, r, c, b, "Expression/Prefix/RHS")
       end
 
-    let value = ast.NodeWith[ast.ExpOperation](
+    let value = ast.NodeWith[ast.Expression](
       _Build.info(d, r), c, ast.ExpOperation(None, op', rhs'))
     (value, b)
 

--- a/eohippus/parser/expression_builder.pony
+++ b/eohippus/parser/expression_builder.pony
@@ -379,7 +379,7 @@ class ExpressionBuilder
     match_case.set_body(
       Conj(
         [ bar
-          Bind(match_case_pattern, Disj([ exp_decl; exp_atom ]))
+          Bind(match_case_pattern, Disj([ exp_decl; exp_prefix; exp_hash ]))
           Ques(Conj([ kwd_if; Bind(match_case_condition, seq) ]))
           equal_arrow
           Bind(match_case_body, seq) ]),
@@ -474,7 +474,7 @@ class ExpressionBuilder
     exp_try.set_body(
       Conj(
         [ kwd_try
-          Bind(try_body, seq)
+          Bind(try_body, Ques(seq))
           Ques(Conj([ kwd_else; Bind(try_else_block, seq) ]))
           kwd_end ]),
       _ExpActions~_try(try_body, try_else_block))

--- a/eohippus/parser/expression_builder.pony
+++ b/eohippus/parser/expression_builder.pony
@@ -591,12 +591,7 @@ class ExpressionBuilder
 
     // call_args_pos <= seq (',' seq)*
     call_args_pos.set_body(
-      Conj(
-        [ seq
-          Star(
-            Conj(
-              [ comma
-                seq ])) ]))
+      Conj([ seq; Star(Conj([ comma; seq ])) ]))
 
     // call_args_named <= 'where' call_arg_named
     //                    (',' call_arg_named)*
@@ -713,9 +708,9 @@ class ExpressionBuilder
       Conj(
         [ at
           Bind(ffi_identifier, Disj([ id; literal_string ]))
-          Ques(Bind(ffi_type_args, type_args))
+          Bind(ffi_type_args, Ques(type_args))
           Bind(ffi_call_args, call_args)
-          Bind(ffi_partial, ques) ]),
+          Bind(ffi_partial, Ques(ques)) ]),
       _ExpActions~_ffi(
         ffi_identifier, ffi_type_args, ffi_call_args, ffi_partial))
 

--- a/eohippus/parser/src_file_builder.pony
+++ b/eohippus/parser/src_file_builder.pony
@@ -102,19 +102,16 @@ class SrcFileBuilder
     b: Bindings)
     : ((ast.Node | None), Bindings)
   =>
-    ( let es': ast.NodeSeqWith[ast.ErrorSection],
-      let t1': ast.NodeSeqWith[ast.Trivia],
+    ( let t1': ast.NodeSeqWith[ast.Trivia],
       let ds': ast.NodeSeqWith[ast.DocString],
       let us': ast.NodeSeqWith[ast.Using],
       let td': ast.NodeSeqWith[ast.Typedef] )
     =
       recover val
-        let errs = Array[ast.NodeWith[ast.ErrorSection]]
-        ( errs,
-          _Build.values_and_errors[ast.Trivia](b, t1, r, errs),
-          _Build.values_and_errors[ast.DocString](b, ds, r, errs),
-          _Build.values_and_errors[ast.Using](b, us, r, errs),
-          _Build.values_and_errors[ast.Typedef](b, td, r, errs) )
+        ( _Build.values_and_errors[ast.Trivia](b, t1, r),
+          _Build.values_and_errors[ast.DocString](b, ds, r),
+          _Build.values_and_errors[ast.Using](b, us, r),
+          _Build.values_and_errors[ast.Typedef](b, td, r) )
       end
 
     let pt' = _Build.values_with[ast.Trivia](b, pt, r)
@@ -124,7 +121,6 @@ class SrcFileBuilder
       where
         pre_trivia' = t1',
         doc_strings' = ds',
-        error_sections' = es',
         post_trivia' = pt')
     (value, b)
 

--- a/eohippus/test/_assert.pony
+++ b/eohippus/test/_assert.pony
@@ -116,7 +116,6 @@ primitive _Assert
   =>
     let promise = Promise[Bool]
     let segments = Cons[parser.Segment](source, Nil[parser.Segment])
-    let start = parser.Loc(segments, 0)
     let pony_parser = parser.Parser(segments)
     let callback =
       recover val
@@ -155,7 +154,8 @@ primitive _Assert
     end
 
   fun _get_error_sections(node: ast.Node, msg: String ref) =>
-    for es in node.error_sections().values() do
+    match node
+    | let es: ast.NodeWith[ast.ErrorSection] =>
       if msg.size() > 0 then
         msg.append("; ")
       end

--- a/eohippus/test/_test_ast_parse_node.pony
+++ b/eohippus/test/_test_ast_parse_node.pony
@@ -25,7 +25,6 @@ class iso _TestAstParseNodeAnnotation is UnitTest
           "doc_strings": [],
           "pre_trivia": [],
           "post_trivia": [ 3 ],
-          "error_sections": [],
           "identifiers": [ 1 ],
           "children": [
             { "name": "Token", "string": "/" },

--- a/eohippus/test/_test_parser_expression.pony
+++ b/eohippus/test/_test_parser_expression.pony
@@ -13,6 +13,7 @@ primitive _TestParserExpression
     test(_TestParserExpressionIf)
     test(_TestParserExpressionIfDef)
     test(_TestParserExpressionIfExpression)
+    test(_TestParserExpressionIfComplex)
     test(_TestParserExpressionSequence)
     test(_TestParserExpressionJump)
     test(_TestParserExpressionInfix)
@@ -451,6 +452,59 @@ class iso _TestParserExpressionIfExpression is UnitTest
             {
               "name": "Keyword",
               "string": "end"
+            }
+          ]
+        }
+      """
+
+    _Assert.test_all(h, [ _Assert.test_match(h, rule, setup.data, src, exp) ])
+
+class iso _TestParserExpressionIfComplex is UnitTest
+  fun name(): String => "parser/expression/If/complex"
+  fun exclusion_group(): String => "parser/expression"
+
+  fun apply(h: TestHelper) =>
+    let setup = _TestSetup(name())
+    let rule = setup.builder.expression.item
+
+    let src =
+      """
+        if a and not b then
+          c
+        end
+      """
+    let exp =
+      """
+        {
+          "name": "ExpIf",
+          "conditions": [ 1 ],
+          "children": [
+            { "name": "Keyword", "string": "if" },
+            {
+              "name": "IfCondition",
+              "if_true": 0,
+              "then_block": 2,
+              "children": [
+                {
+                  "name": "ExpOperation",
+                  "lhs": 0,
+                  "op": 1,
+                  "rhs": 2,
+                  "children": [
+                    { "name": "ExpAtom" },
+                    { "name": "Keyword", "string": "and" },
+                    {
+                      "name": "ExpOperation",
+                      "op": 0,
+                      "rhs": 1,
+                      "children": [
+                        { "name": "Keyword", "string": "not" },
+                        { "name": "ExpAtom" }
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/eohippus/test/_test_parser_src_file.pony
+++ b/eohippus/test/_test_parser_src_file.pony
@@ -693,9 +693,6 @@ class iso _TestParserSrcFileUsingErrorSection is UnitTest
             2,
             4
           ],
-          "error_sections": [
-            3
-          ],
           "pre_trivia": [
             0,
             1

--- a/eohippus/test/_test_parser_src_file.pony
+++ b/eohippus/test/_test_parser_src_file.pony
@@ -1318,60 +1318,10 @@ class iso _TestParserSrcFileStdlibErrorSection is UnitTest
 
     let src =
       """
-        use @snprintf[I32](str: Pointer[U8] tag, size: USize, fmt: Pointer[U8] tag, ...)
-          if not windows
-        use @_snprintf[I32](str: Pointer[U8] tag, count: USize, fmt: Pointer[U8] tag, ...)
-          if windows
+        use @snprintf[I32](str: Pointer[U8] tag, size: USize, fmt: Pointer[U8] tag, ...) if not windows
+        use @_snprintf[I32](str: Pointer[U8] tag, count: USize, fmt: Pointer[U8] tag, ...) if windows
 
         primitive _ToString
-          \"\"\"
-          Worker type providing simple to string conversions for numbers.
-          \"\"\"
-          fun _u64(x: U64, neg: Bool): String iso^ =>
-            let table = "0123456789"
-            let base: U64 = 10
-
-            recover
-              var s = String(31)
-              var value = x
-
-              try
-                if value == 0 then
-                  s.push(table(0)?)
-                else
-                  while value != 0 do
-                    let index = ((value = value / base) - (value * base))
-                    s.push(table(index.usize())?)
-                  end
-                end
-              end
-
-              if neg then s.push('-') end
-              s .> reverse_in_place()
-            end
-
-          fun _u128(x: U128, neg: Bool): String iso^ =>
-            let table = "0123456789"
-            let base: U128 = 10
-
-            recover
-              var s = String(31)
-              var value = x
-
-              try
-                if value == 0 then
-                  s.push(table(0)?)
-                else
-                  while value != 0 do
-                    let index = (value = value / base) - (value * base)
-                    s.push(table(index.usize())?)
-                  end
-                end
-              end
-
-              if neg then s.push('-') end
-              s .> reverse_in_place()
-            end
 
           fun _f64(x: F64): String iso^ =>
             recover


### PR DESCRIPTION
This PR includes several fixes to the parser; the parser can now handle the entire `builtin` package of the standard library.

Closes #18 